### PR TITLE
Correct syntax for add-apt-repository

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -146,7 +146,7 @@ EOF
 fi
 
 sudo apt install -y software-properties-common linux-headers-generic
-sudo add-apt-repository -y 'ppa:morphis/anbox-support'
+sudo add-apt-repository -y ppa:~morphis/anbox-support
 sudo apt update
 sudo apt install -y anbox-modules-dkms
 


### PR DESCRIPTION
Updated script with the correct syntax for add-apt-repository, without which installer provides error.