### PR TITLE
Add Zorin as supported OS

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -30,7 +30,7 @@ if ! uname -a | grep -q x86_64 ; then
 	exit 1
 fi
 
-SUPPORTED_DISTROS=("Ubuntu" "LinuxMint" "neon" "elementary")
+SUPPORTED_DISTROS=("Ubuntu" "LinuxMint" "neon" "elementary" "Zorin")
 DISTRIB_ID="$(lsb_release -i -s)"
 
 function contains() {


### PR DESCRIPTION
Zorin OS is based on Ubuntu 16.04 LTS, just like the rest of the already supported distros.